### PR TITLE
fixed typo in MAZE heading

### DIFF
--- a/_docs/2. Learning the Basics/Other Packages.md
+++ b/_docs/2. Learning the Basics/Other Packages.md
@@ -28,7 +28,7 @@ These are short guides to getting started with other, specialized packages that 
 
 (under construction)
 
-### Multiscale Atomisric Zeolite Environment (MAZE)
+### Multiscale Atomistic Zeolite Simulation Environment (MAZE)
 
 #### What is MAZE?
 


### PR DESCRIPTION
We follow a different naming convention here https://kul-group.github.io/MAZE-sim/build/html/background.html
> Multiscale Atomistic Zeotype Simulation Environment (MAZE) ...

 compared to the paper title 
> Multiscale Atomic Zeolite Simulation Environment (MAZE) 

I have corrected the spelling error.